### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/jtzero/cle-gunners/security/code-scanning/1](https://github.com/jtzero/cle-gunners/security/code-scanning/1)

To fix this problem, we should add an explicit `permissions` block to the workflow to restrict the permissions granted to the `GITHUB_TOKEN`. Since the workflow does not show any steps requiring write access, the recommended minimal setting is `contents: read`. This should be added at the workflow root (after the `name:` and before or after the `on:` block), which will apply to all jobs unless overridden. Edit `.github/workflows/test.yml` and insert:
```
permissions:
  contents: read
```
after the `name: Test` line (best practice for readability is to place it right after `name: ...`). No changes to imports, methods, or other code files are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
