### PR TITLE
Add Instagram link to menu.json

### DIFF
--- a/src/config/menu.json
+++ b/src/config/menu.json
@@ -31,6 +31,10 @@
       "url": "https://www.facebook.com/ArsenalFansCleveland"
     },
     {
+      "name": "Follow our Instagram",
+      "url": "https://www.instagram.com/cle_gooners"
+    },
+    {
       "name": "Join us on Bluesky",
       "url": "https://bsky.app/profile/cleveland-arsenal.bsky.social"
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Follow our Instagram” link to the site navigation menu, positioned between the existing Facebook and Bluesky links for consistency.
  * Users can now access our Instagram profile directly from the menu across the site, on both desktop and mobile.
  * All other menu items and their order remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->