### PR TITLE
change dependabot to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,4 @@ updates:
   - package-ecosystem: "npm" # Replace with your package ecosystem (e.g., "bundler", "maven", "docker")
     directory: "/" # Location of your manifest file (e.g., package.json)
     schedule:
-      interval: "weekly"
+      interval: "monthly"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted automated dependency update schedule: npm dependency checks now run monthly (reduced from weekly).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->