### PR TITLE
added clubs page to list local soccer groups around CLE, still a wip

### DIFF
--- a/src/pages/clubs.astro
+++ b/src/pages/clubs.astro
@@ -1,0 +1,34 @@
+---
+import Base from "../layouts/Base.astro";
+
+export const meta = {
+  title: "Local Soccer Clubs",
+  description: "A simple list of soccer clubs around Cleveland."
+};
+---
+
+<Base {...meta}>
+  <main class="px-4 py-10 max-w-4xl mx-auto">
+    <h1 class="text-3xl font-bold mb-6">Local Soccer Clubs</h1>
+    <p class="mb-8">
+      Just a running list of local clubs and pickup groups around the city.
+      I’ll keep adding to this as I find more.
+    </p>
+
+    <div class="space-y-6">
+      <div class="bg-white rounded-md p-5 shadow-sm">
+        <h2 class="text-xl font-semibold">Example FC</h2>
+        <p>Neighborhood: Ohio City</p>
+        <p>Plays: Sundays at 2pm</p>
+        <a href="#" class="text-red-600 underline">Website</a>
+      </div>
+
+      <div class="bg-white rounded-md p-5 shadow-sm">
+        <h2 class="text-xl font-semibold">Cleveland Park Kickers</h2>
+        <p>Neighborhood: Tremont</p>
+        <p>Plays: Wednesday evenings</p>
+        <a href="#" class="text-red-600 underline">Facebook</a>
+      </div>
+    </div>
+  </main>
+</Base>


### PR DESCRIPTION
Added a club's page that has fake data for now. We can add real teams later. to see the page you have to go to whatever the local host is /clubs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added a Local Soccer Clubs page featuring neighborhood information, play times, and direct links to club details for easy discovery.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->