### PR TITLE
add fa cup against portsmouth

### DIFF
--- a/src/components/MatchTracker.astro
+++ b/src/components/MatchTracker.astro
@@ -189,6 +189,7 @@ const { styling } = Astro.props;
   const CACHE_VERSION = 1;
   const DOUBLE_HEADER_FLAG = "double-header";
   const INCLUDE_CL = true;
+  const INCLUDE_FAC = true;
   const imageLoadListenersInit = {
     "match-tracker": {
       home: false,
@@ -421,6 +422,7 @@ const { styling } = Astro.props;
       });
   };
 
+  // TODO prefix with sort
   const laterThanNow = (matches: Array<MatchType>, today: Date) => {
     const sortedMatches = matches.sort((a, b) =>
       a.utcDate.localeCompare(b.utcDate),
@@ -455,22 +457,11 @@ const { styling } = Astro.props;
   ) => {
     const json = await response.json();
 
-    let doubleHeaderMatch: MatchType | undefined = undefined;
     const nearestMatches = laterThanNow(
       [...existingMatches, ...json.matches],
       today,
     );
-    const nearestMatch = filterMatchesByCompetitionCodes(
-      nearestMatches,
-      competitionCodes,
-    )[0];
-    if (nearestMatches.length > 1) {
-      const otherMatches = otherMatchesOnSameDay(nearestMatch, nearestMatches);
-      if (otherMatches.length > 0) {
-        doubleHeaderMatch = otherMatches[0];
-      }
-    }
-    return [nearestMatch, doubleHeaderMatch].filter(Boolean);
+    return filterMatchesByCompetitionCodes(nearestMatches, competitionCodes);
   };
   const hideDoubleHeaderItems = (
     matchTracker: HTMLElement,
@@ -511,6 +502,14 @@ const { styling } = Astro.props;
     return matches.filter((match) => {
       return competitionCodes.includes(match.competition.code);
     });
+  };
+  const isDoubleHeader = (matches: Array<MatchType>): boolean => {
+    if (matches.length < 2) {
+      return false;
+    }
+    const nearestMatch = matches[0];
+    const otherMatches = otherMatchesOnSameDay(nearestMatch, matches);
+    return otherMatches.length > 0;
   };
   const digCache = (
     today: Date,
@@ -604,7 +603,7 @@ const { styling } = Astro.props;
     );
     if (cachedMatches.length > 0) {
       let flags = [];
-      if (cachedMatches.length > 1) {
+      if (isDoubleHeader(cachedMatches)) {
         flags.push(DOUBLE_HEADER_FLAG);
       }
       if (cachedMatches.length > 0) {
@@ -613,7 +612,7 @@ const { styling } = Astro.props;
           runningUpdates = true;
           updateTracker(matchTracker, cachedMatches[0], audioPlayer, flags);
         }
-        if (cachedMatches.length > 1) {
+        if (flags.includes(DOUBLE_HEADER_FLAG)) {
           if (!isMatchInSlot("match-tracker-double-header", cachedMatches[1])) {
             matchTrackerDoubleHeader.classList.remove("hidden");
             updateTracker(
@@ -714,13 +713,13 @@ const { styling } = Astro.props;
         }),
       );
       let flags = [];
-      if (nearestMatches.length > 1) {
+      if (isDoubleHeader(nearestMatches)) {
         flags.push(DOUBLE_HEADER_FLAG);
       }
       if (!isMatchInSlot("match-tracker", nearestMatches[0])) {
         updateTracker(matchTracker, nearestMatches[0], audioPlayer, flags);
       }
-      if (nearestMatches.length > 1) {
+      if (flags.includes(DOUBLE_HEADER_FLAG)) {
         matchTrackerDoubleHeader.classList.remove("hidden");
         if (!isMatchInSlot("match-tracker-double-header", nearestMatches[1])) {
           updateTracker(
@@ -768,8 +767,12 @@ const { styling } = Astro.props;
   });
   let addedPolling = false;
   const competitionCodes = (() => {
-    if (INCLUDE_CL) {
+    if (INCLUDE_CL && INCLUDE_FAC) {
+      return ["CL", "PL", "FAC"];
+    } else if (INCLUDE_CL) {
       return ["CL", "PL"];
+    } else if (INCLUDE_FAC) {
+      return ["PL", "FAC"];
     } else {
       return ["PL"];
     }

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -64,9 +64,9 @@ const manualFixturesCollection = defineCollection({
     filters: z.object({
       dateFrom: z.string().date().optional(),
       dateTo: z.string().date().optional(),
-      permission: z.string(),
+      permission: z.string().optional(),
       competitions: z.coerce.number().optional(),
-      limit: z.number(),
+      limit: z.number().optional(),
     }),
     resultSet: z.object({
       count: z.number(),

--- a/src/content/manual-fixtures/2026-01-08.json
+++ b/src/content/manual-fixtures/2026-01-08.json
@@ -1,0 +1,73 @@
+{
+  "filters": {},
+  "resultSet": {
+    "count": 1
+  },
+  "matches": [
+    {
+      "area": {
+        "id": 2072,
+        "name": "England",
+        "code": "ENG",
+        "flag": "https://crests.football-data.org/770.svg"
+      },
+      "competition": {
+        "id": 2055,
+        "name": "FA CUP",
+        "code": "FAC",
+        "type": "CUP",
+        "emblem": "https://crests.football-data.org/FAC.png"
+      },
+      "season": {
+        "id": 0,
+        "startDate": "2025-08-15",
+        "endDate": "2026-05-24",
+        "currentMatchday": 3,
+        "winner": null
+      },
+      "id": 538007,
+      "utcDate": "2026-01-11T14:00:00Z",
+      "status": "TIMED",
+      "matchday": 23,
+      "stage": "CUP",
+      "group": null,
+      "lastUpdated": "2026-01-08T00:20:53Z",
+      "homeTeam": {
+        "id": 325,
+        "name": "Portsmouth FC",
+        "shortName": "Portsmouth",
+        "tla": "POR",
+        "crest": "https://crests.football-data.org/325.png",
+        "address": "Frogmore Road Portsmouth PO4 8RA",
+        "website": "http://www.portsmouthfc.co.uk",
+        "founded": 1898,
+        "clubColors": "Blue / White",
+        "venue": "Fratton Park",
+        "lastUpdated": "2024-08-27T19:14:22Z"
+      },
+      "awayTeam": {
+        "id": 57,
+        "name": "Arsenal FC",
+        "shortName": "Arsenal",
+        "tla": "ARS",
+        "crest": "https://crests.football-data.org/57.png"
+      },
+      "score": {
+        "winner": null,
+        "duration": "REGULAR",
+        "fullTime": {
+          "home": null,
+          "away": null
+        },
+        "halfTime": {
+          "home": null,
+          "away": null
+        }
+      },
+      "odds": {
+        "msg": "Activate Odds-Package in User-Panel to retrieve odds."
+      },
+      "referees": []
+    }
+  ]
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional support for FA Cup competitions in match tracking.

* **Improvements**
  * Improved double-header detection and UI handling for back-to-back matches.
  * Made fixture configuration more flexible by allowing permission and limit to be optional.
  * Added a sample manual fixture dataset for testing and reference.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->