### PR TITLE
fix menu freezing scroll when after navigation

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -239,6 +239,7 @@ const { main }: { main: NavigationLink[] } = menu;
     [...self!.querySelectorAll("[data-js-close=true]")].map((navItem) => {
       navItem.addEventListener("click", () => {
         navToggle!.checked = false;
+        document.body.classList.remove("overflow-hidden");
       });
     });
   });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where page scrolling could remain locked after closing the navigation menu, ensuring normal scrolling behavior is restored when the menu is dismissed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->