### PR TITLE
allow square header media to be stand alone

### DIFF
--- a/src/components/Post.astro
+++ b/src/components/Post.astro
@@ -184,6 +184,15 @@ const mediaClasses = (() => {
         imagePostData.parsedImageWidth == imagePostData.parsedImageHeight &&
         (!multimediaPlacement || multimediaPlacement == "header")
       ) {
+        const hasBodySlot = Boolean(
+          hasTextBody ||
+            hasDynamicMedia ||
+            multimediaPlacement == "body" ||
+            showReadMore,
+        );
+        if (!hasBodySlot) {
+          return "tile-with-square-header-media-no-body";
+        }
         return "tile-with-square-header-media";
       } else if (hasHeaderMultimedia) {
         return "tile-with-header-media";
@@ -370,6 +379,17 @@ const hasHeaderSlot = Boolean(hasHeaderMultimedia || hasDynamicMedia);
     height: auto;
     @variant md {
       grid-template-columns: 1fr 1fr;
+      grid-template-rows: 1fr;
+      height: auto;
+    }
+  }
+  .tile-with-square-header-media-no-body {
+    @apply grid;
+    grid-template-columns: 1fr;
+    grid-template-rows: 1fr;
+    height: auto;
+    @variant md {
+      grid-template-columns: 1fr;
       grid-template-rows: 1fr;
       height: auto;
     }

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -1,20 +1,20 @@
 ---
-import * as fs from 'fs';
-import * as server from "astro:config/server"
+import * as fs from "fs";
+import * as server from "astro:config/server";
 import Base from "@/layouts/Base.astro";
 import { getCollection, getEntry, getEntries } from "astro:content";
 import Post from "@/components/Post.astro";
 
 export async function getStaticPaths() {
-  const pages = await getCollection("pages", (page)=> {
+  const pages = await getCollection("pages", (page) => {
     return !fs.existsSync(`${server.srcDir}/${page.filePath}`);
   });
   return pages.map((page) => {
     return {
-        params: {
-          slug: page.id,
-        },
-      };
+      params: {
+        slug: page.id,
+      },
+    };
   });
 }
 const { slug } = Astro.params;
@@ -24,17 +24,25 @@ if (!page) {
   return Astro.redirect("/404");
 }
 // TODO: test that all entries are returned
-const subPosts = await getEntries(page.data.posts.map((post_id) => {
-  return {collection: 'posts', id: post_id }
-}));
-
+const subPosts = await getEntries(
+  page.data.posts.map((post_id) => {
+    return { collection: "posts", id: post_id };
+  }),
+);
 ---
 
 <Base title={page.data.title} metaTitle={page.data.metaTitle}>
-  <div data-testid="pinned-items" class="pt-10 bg-light flex items-center justify-center flex-col">
+  <div
+    data-testid="pinned-items"
+    class="bg-light flex flex-col items-center justify-center pt-10"
+  >
     {
       subPosts.map((subPost) => (
-        <Post post={subPost} styling="tile w-3/4 mb-6 shadow bg-white scroll-mt-5" displayReadMore={false}/>
+        <Post
+          post={subPost}
+          styling="tile max-w-3/4 mb-6 shadow bg-white scroll-mt-5"
+          displayReadMore={false}
+        />
       ))
     }
   </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new square header media layout variant optimized for displaying tiles without body content.

* **Style**
  * Improved responsive width constraints for tile containers and enhanced layout spacing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jtzero/cle-gunners/pull/381?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->