### PR TITLE
side by side GA script with umami

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -8,7 +8,7 @@ const usePageAnalytics = (() => {
   }
 })();
 export default {
-  use)ageAnalytics: usePageAnalytics,
+  usePageAnalytics: usePageAnalytics,
   site: {
     title: "Cleveland Arsenal|Cleveland Gooners",
     favicon: "/images/favicon.png",

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -1,14 +1,14 @@
-const useGoogleAnalytics = (() => {
+const usePageAnalytics = (() => {
   if (process.env.NODE_ENV === "production") {
-    console.log("Google Analytics is enabled");
+    console.log("Page Analytics is enabled");
     return true;
   } else {
-    console.log("Google Analytics is disabled");
+    console.log("Page Analytics is disabled");
     return false;
   }
 })();
 export default {
-  useGoogleAnalytics: useGoogleAnalytics,
+  use)ageAnalytics: usePageAnalytics,
   site: {
     title: "Cleveland Arsenal|Cleveland Gooners",
     favicon: "/images/favicon.png",

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -139,6 +139,26 @@ const keywordsArray = keywords || [];
     />
     <meta name="twitter:card" content="summary_large_image" />
 
+    <!-- Google analytics -->
+    {
+      config.usePageAnalytics && (
+        <>
+          <script
+            async
+            src="https://www.googletagmanager.com/gtag/js?id=G-XCWV76HQNY"
+          />
+          <script>
+            window.dataLayer = window.dataLayer || [];
+            function gtag() {
+              dataLayer.push(arguments);
+            }
+            gtag("js", new Date());
+
+            gtag("config", "G-XCWV76HQNY");
+          </script>
+        </>
+      )
+    }
     <!-- Page analytics -->
     {
       config.usePageAnalytics && (

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -141,7 +141,7 @@ const keywordsArray = keywords || [];
 
     <!-- Page analytics -->
     {
-      config.useGoogleAnalytics && (
+      config.usePageAnalytics && (
         <>
           <script defer src="https://cloud.umami.is/script.js" data-website-id="fd3e632b-4fbf-41ee-a4eb-e70f3c9df273"></script>
         </>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -145,6 +145,7 @@ const keywordsArray = keywords || [];
         <>
           <script defer src="https://cloud.umami.is/script.js" data-website-id="fd3e632b-4fbf-41ee-a4eb-e70f3c9df273"></script>
         </>
+      )
     }
   </head>
   <body class="flex min-h-screen flex-col">

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -139,25 +139,12 @@ const keywordsArray = keywords || [];
     />
     <meta name="twitter:card" content="summary_large_image" />
 
-    <!-- Google analytics -->
+    <!-- Page analytics -->
     {
       config.useGoogleAnalytics && (
         <>
-          <script
-            async
-            src="https://www.googletagmanager.com/gtag/js?id=G-XCWV76HQNY"
-          />
-          <script>
-            window.dataLayer = window.dataLayer || [];
-            function gtag() {
-              dataLayer.push(arguments);
-            }
-            gtag("js", new Date());
-
-            gtag("config", "G-XCWV76HQNY");
-          </script>
+          <script defer src="https://cloud.umami.is/script.js" data-website-id="fd3e632b-4fbf-41ee-a4eb-e70f3c9df273"></script>
         </>
-      )
     }
   </head>
   <body class="flex min-h-screen flex-col">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched page analytics from Google Analytics (including the tag manager setup) to Umami.
  * Analytics loading is now controlled by a dedicated page-analytics setting and is conditionally enabled based on the production environment.
  * Umami is injected as a deferred script in the page `<head>` to improve tracking performance and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->