### PR TITLE
match tracker spacing issue

### DIFF
--- a/src/components/MatchTracker.astro
+++ b/src/components/MatchTracker.astro
@@ -65,7 +65,7 @@ const { styling } = Astro.props;
       </div>
       <div class="team-names" data-show-after-load>
         <span updates="home-team-name" class="text-xl font-bold"></span>
-        <span></span>
+        <span style="width: 1rem;"></span>
         <span updates="away-team-name" class="text-xl font-bold"></span>
       </div>
     </div>
@@ -136,7 +136,7 @@ const { styling } = Astro.props;
     </div>
     <div class="team-names" data-show-after-load>
       <span updates="home-team-name" class="text-xl font-bold"></span>
-      <span></span>
+      <span style="width: 1rem;"></span>
       <span updates="away-team-name" class="text-xl font-bold"></span>
     </div>
   </Fragment>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved match tile alignment by reserving consistent space in team-name layouts.
  * Updated single-header and double-header match displays for more uniform spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->